### PR TITLE
Restore backup - implemented without hardcoding anything

### DIFF
--- a/HBC/meta.xml
+++ b/HBC/meta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <app version="1.1">
 	<name>ww-43db-patcher</name>
-	<version>0.1</version>
+	<version>0.2</version>
         <release_date>20200625000000</release_date>
 	<coder>DarkMatterCore</coder>
 	<short_description>vWii WiiWare 43DB patcher.</short_description>

--- a/source/ardb.c
+++ b/source/ardb.c
@@ -179,7 +179,7 @@ skip2:
     {
         for(u32 i = 0; i < ardb->entry_count; i++) ardb->entries[i] = 0x5A5A5A00; /* "ZZZ.". */
     } else {
-        for(u32 i = 0; i < ardb->entry_count; i++) ardb->entries[i] = backupData[i]; /* "ZZZ.". */
+        for(u32 i = 0; i < ardb->entry_count; i++) ardb->entries[i] = backupData[i]; /* patch from array. */
     }
     
     /* Save modified aspect ratio database data to U8 archive buffer. */

--- a/source/ardb.h
+++ b/source/ardb.h
@@ -40,6 +40,7 @@ typedef enum {
 } AspectRatioDatabaseType;
 
 /// Patches an aspect ratio database stored inside the System Menu's U8 archive.
-bool ardbPatchDatabaseFromSystemMenuArchive(u8 type);
+/// If a pointer is passed, it patches with data it points to instead
+bool ardbPatchDatabaseFromSystemMenuArchive(u8 type, const u32 *backupData);
 
 #endif /* __ARDB_H__ */

--- a/source/main.c
+++ b/source/main.c
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
     
     printf("OK!\n\n");
 
-    printf("\nPress + to patch 43DB, press - to restore the backup, or press home to abort");
+    printf("Press + to patch 43DB, press - to restore the backup, or press home to abort\n");
     bool restoreBackup;
     while (true)
     {

--- a/source/utils.c
+++ b/source/utils.c
@@ -20,6 +20,7 @@
 
 #include <fat.h>
 #include <sdcard/wiisd_io.h>
+#include <sys/stat.h>
 
 #include "utils.h"
 
@@ -37,9 +38,7 @@ static s32 g_isfsFd ATTRIBUTE_ALIGN(32) = 0;
 static char g_isfsFilePath[ISFS_MAXPATH] ATTRIBUTE_ALIGN(32) = {0};
 static fstats g_isfsFileStats ATTRIBUTE_ALIGN(32) = {0};
 
-#ifdef BACKUP_U8_ARCHIVE
 static bool g_sdCardMounted = false;
-#endif
 
 /* Function prototypes. */
 
@@ -359,7 +358,6 @@ out:
     return success;
 }
 
-#ifdef BACKUP_U8_ARCHIVE
 bool utilsMountSdCard(void)
 {
     if (g_sdCardMounted) return true;
@@ -374,7 +372,22 @@ void utilsUnmountSdCard(void)
     __io_wiisd.shutdown();
     g_sdCardMounted = false;
 }
-#endif
+
+int utilsGetFileSize(const char *filename)
+{
+    struct stat st;
+    stat(filename, &st);
+    return st.st_size;
+}
+
+u32 *utilsReadFile(const char *filename, int filesize)
+{
+    u32 *backup = (u32 *) malloc(filesize);
+    FILE *file = fopen(filename, "rb");
+    fread(backup, filesize, 1, file);
+    fclose(file);
+    return backup;
+}
 
 static u32 utilsButtonsDownAll(void)
 {

--- a/source/utils.h
+++ b/source/utils.h
@@ -106,9 +106,9 @@ ALWAYS_INLINE tmd *utilsGetTMDFromSignedBlob(signed_blob *stmd)
 void *utilsReadFileFromFlashFileSystem(const char *path, u32 *out_size);
 bool utilsWriteDataToFlashFileSystemFile(const char *path, void *buf, u32 size);
 
-#ifdef BACKUP_U8_ARCHIVE
 bool utilsMountSdCard(void);
 void utilsUnmountSdCard(void);
-#endif
+int utilsGetFileSize(const char *filename);
+u32 *utilsReadFile(const char *filename, int filesize);
 
 #endif /* __UTILS_H__ */


### PR DESCRIPTION
follow up to #3, this time without hardcoding any values in the application
I am yet to test this on hardware, but I will do so soon.
I have added the needed checks for filesize, and whether it exists at all
the backup should only be created if one doesn't exist already. This might not be helpful for people who have lost the backup, but still wish to restore which the previous scenario would have covered. I'm not sure if it's worth implementing some checks comparing the first few bytes before writing the backup, to ensure it isn't one with only ZZZ. entries, but that's your call